### PR TITLE
Custom SwiftUI Candidate List + standalone Example app (#5)

### DIFF
--- a/Example/ExampleApp.swift
+++ b/Example/ExampleApp.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import BSMCore
+import BSMCandidateUI
+
+/// Standalone harness app for visually reviewing and UI-testing the Candidate
+/// List without installing an input method (issue #5). It feeds the shared
+/// `CandidateListView` from fixed mock candidate pages.
+@main
+struct ExampleApp: App {
+    var body: some Scene {
+        Window("BSM Candidate List Example", id: "main") {
+            ContentView()
+        }
+        .windowResizability(.contentSize)
+    }
+}
+
+struct ContentView: View {
+    @State private var showsCode = true
+    @State private var pageIndex = 0
+
+    static let pages: [[Candidate]] = [
+        [
+            Candidate(code: BSMCode("1"), word: "一"),
+            Candidate(code: BSMCode("12"), word: "下"),
+            Candidate(code: BSMCode("123"), word: "丁"),
+            Candidate(code: BSMCode("1234"), word: "七"),
+            Candidate(code: BSMCode("12345"), word: "丈"),
+            Candidate(code: BSMCode("13"), word: "万"),
+            Candidate(code: BSMCode("134"), word: "丑"),
+            Candidate(code: BSMCode("19"), word: "且"),
+            Candidate(code: BSMCode("199"), word: "world"),
+        ],
+        [
+            Candidate(code: BSMCode("2"), word: "中"),
+            Candidate(code: BSMCode("23"), word: "串"),
+            Candidate(code: BSMCode("234"), word: "丸"),
+        ],
+    ]
+
+    private var candidates: [Candidate] { Self.pages[pageIndex] }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            CandidateListView(candidates: candidates, showsCode: showsCode, selectedIndex: 0)
+
+            HStack(spacing: 12) {
+                Button("Toggle Code") { showsCode.toggle() }
+                    .accessibilityIdentifier("toggle-code")
+                Button("Next Page") { pageIndex = (pageIndex + 1) % Self.pages.count }
+                    .accessibilityIdentifier("next-page")
+            }
+            Text("Page \(pageIndex + 1) of \(Self.pages.count)")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("page-indicator")
+        }
+        .padding(40)
+        .frame(minWidth: 380, minHeight: 360)
+    }
+}

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>hk.ignition.inputmethod.BSMInputMethod.Example</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/ExampleUITests/CandidateListUITests.swift
+++ b/ExampleUITests/CandidateListUITests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+/// Drives the standalone Example app to verify the Candidate List renders the
+/// numbered word / muted code rows and that the `+` code column toggles (#5).
+final class CandidateListUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    func testRowsShowSelectionNumberWordAndCode() {
+        XCTAssertTrue(app.staticTexts["candidate-number-1"].waitForExistence(timeout: 5))
+        XCTAssertEqual(app.staticTexts["candidate-number-1"].label, "1")
+        XCTAssertEqual(app.staticTexts["candidate-word-1"].label, "一")
+        XCTAssertEqual(app.staticTexts["candidate-code-1"].label, "1")
+
+        // Nine candidates on the first page -> selection numbers 1...9.
+        XCTAssertTrue(app.staticTexts["candidate-number-9"].exists)
+        XCTAssertEqual(app.staticTexts["candidate-word-9"].label, "world")
+    }
+
+    func testToggleHidesAndShowsCodeColumn() {
+        XCTAssertTrue(app.staticTexts["candidate-code-1"].waitForExistence(timeout: 5))
+
+        app.buttons["toggle-code"].click()
+        XCTAssertFalse(app.staticTexts["candidate-code-1"].exists)
+        // Word column remains.
+        XCTAssertTrue(app.staticTexts["candidate-word-1"].exists)
+
+        app.buttons["toggle-code"].click()
+        XCTAssertTrue(app.staticTexts["candidate-code-1"].waitForExistence(timeout: 2))
+    }
+
+    func testNextPageChangesCandidates() {
+        XCTAssertTrue(app.staticTexts["candidate-word-1"].waitForExistence(timeout: 5))
+        XCTAssertEqual(app.staticTexts["candidate-word-1"].label, "一")
+
+        app.buttons["next-page"].click()
+        XCTAssertEqual(app.staticTexts["candidate-word-1"].label, "中")
+        // Second page has three candidates; there is no fourth row.
+        XCTAssertFalse(app.staticTexts["candidate-number-4"].exists)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     products: [
         .library(name: "BSMCore", targets: ["BSMCore"]),
+        .library(name: "BSMCandidateUI", targets: ["BSMCandidateUI"]),
         .executable(name: "bsm-db-build", targets: ["BSMDatabaseBuilder"]),
     ],
     dependencies: [
@@ -14,6 +15,9 @@ let package = Package(
     targets: [
         .target(name: "BSMCore"),
         .testTarget(name: "BSMCoreTests", dependencies: ["BSMCore"]),
+
+        .target(name: "BSMCandidateUI", dependencies: ["BSMCore"]),
+        .testTarget(name: "BSMCandidateUITests", dependencies: ["BSMCandidateUI", "BSMCore"]),
 
         // Database builder: pure logic lives in the library so it is testable;
         // the executable is a thin CLI entry point. (ADR 0005)

--- a/Sources/BSMCandidateUI/CandidateListView.swift
+++ b/Sources/BSMCandidateUI/CandidateListView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import BSMCore
+
+/// The Candidate List: numbered candidate words with an optional muted BSM code
+/// column. Reproduces the legacy row semantics (selection number, word, and a
+/// toggleable code column) as a custom SwiftUI view rather than `IMKCandidates`
+/// (ADR 0008).
+public struct CandidateListView: View {
+    public let candidates: [Candidate]
+    public let showsCode: Bool
+    public let selectedIndex: Int?
+
+    public init(candidates: [Candidate], showsCode: Bool, selectedIndex: Int? = nil) {
+        self.candidates = candidates
+        self.showsCode = showsCode
+        self.selectedIndex = selectedIndex
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            ForEach(Array(candidates.enumerated()), id: \.offset) { index, candidate in
+                CandidateRowView(
+                    number: index + 1,
+                    word: candidate.word,
+                    code: candidate.code.raw,
+                    showsCode: showsCode,
+                    isSelected: index == selectedIndex
+                )
+            }
+        }
+        .padding(6)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
+        .fixedSize()
+        .accessibilityIdentifier("CandidateList")
+    }
+}
+
+struct CandidateRowView: View {
+    let number: Int
+    let word: String
+    let code: String
+    let showsCode: Bool
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("\(number)")
+                .font(.system(.body, design: .rounded))
+                .foregroundStyle(.secondary)
+                .frame(width: 16, alignment: .trailing)
+                .accessibilityIdentifier("candidate-number-\(number)")
+
+            Text(word)
+                .font(.title3)
+                .accessibilityIdentifier("candidate-word-\(number)")
+
+            if showsCode {
+                Spacer(minLength: 16)
+                Text(code)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityIdentifier("candidate-code-\(number)")
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            isSelected ? Color.accentColor.opacity(0.25) : Color.clear,
+            in: RoundedRectangle(cornerRadius: 4)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("candidate-row-\(number)")
+    }
+}

--- a/Sources/BSMCandidateUI/CandidateWindowController.swift
+++ b/Sources/BSMCandidateUI/CandidateWindowController.swift
@@ -1,0 +1,57 @@
+import AppKit
+import SwiftUI
+import BSMCore
+
+/// Hosts the Candidate List in a borderless `NSPanel` positioned by the input
+/// controller near the caret (ADR 0008). The panel is non-activating so it does
+/// not steal key focus from the client application.
+@MainActor
+public final class CandidateWindowController {
+    private let panel: NSPanel
+    private let hostingView: NSHostingView<CandidateListView>
+
+    public init() {
+        hostingView = NSHostingView(rootView: CandidateListView(candidates: [], showsCode: true))
+        panel = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isFloatingPanel = true
+        panel.level = .popUpMenu
+        panel.hasShadow = true
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.contentView = hostingView
+    }
+
+    public var isVisible: Bool { panel.isVisible }
+
+    /// Replace the displayed candidates and resize the panel to fit.
+    public func update(candidates: [Candidate], showsCode: Bool, selectedIndex: Int?) {
+        hostingView.rootView = CandidateListView(
+            candidates: candidates,
+            showsCode: showsCode,
+            selectedIndex: selectedIndex
+        )
+        panel.setContentSize(hostingView.fittingSize)
+    }
+
+    /// Show the panel with its top-left corner at `topLeft` in screen coordinates,
+    /// nudging it back on-screen if it would overflow the bottom edge.
+    public func show(topLeft: NSPoint) {
+        panel.setContentSize(hostingView.fittingSize)
+        var origin = NSPoint(x: topLeft.x, y: topLeft.y - panel.frame.height)
+        if let visible = NSScreen.main?.visibleFrame {
+            if origin.y < visible.minY { origin.y = topLeft.y }
+            origin.x = min(origin.x, visible.maxX - panel.frame.width)
+        }
+        panel.setFrameOrigin(origin)
+        panel.orderFront(nil)
+    }
+
+    public func hide() {
+        panel.orderOut(nil)
+    }
+}

--- a/Sources/BSMCore/BSMCode.swift
+++ b/Sources/BSMCore/BSMCode.swift
@@ -1,0 +1,11 @@
+/// A BSM Code: the raw lookup string of stroke digits (`0`-`9`) plus the `*`
+/// wildcard. It excludes the `.` selection trigger and is at most 6 characters.
+public struct BSMCode: Hashable, Sendable, CustomStringConvertible {
+    public let raw: String
+
+    public init(_ raw: String) {
+        self.raw = raw
+    }
+
+    public var description: String { raw }
+}

--- a/Sources/BSMCore/Candidate.swift
+++ b/Sources/BSMCore/Candidate.swift
@@ -1,0 +1,11 @@
+/// A single conversion choice shown in the Candidate List: the candidate word
+/// and the BSM Code it was matched from.
+public struct Candidate: Hashable, Sendable {
+    public let code: BSMCode
+    public let word: String
+
+    public init(code: BSMCode, word: String) {
+        self.code = code
+        self.word = word
+    }
+}

--- a/Tests/BSMCandidateUITests/CandidateListViewTests.swift
+++ b/Tests/BSMCandidateUITests/CandidateListViewTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import SwiftUI
+import BSMCore
+@testable import BSMCandidateUI
+
+/// Headless rendering checks for the Candidate List. The full interaction
+/// coverage lives in the Example app's XCUITests (issue #5); these run in
+/// `swift test` without a GUI session.
+@MainActor
+struct CandidateListViewTests {
+    private let candidates = [
+        Candidate(code: BSMCode("1"), word: "一"),
+        Candidate(code: BSMCode("123456"), word: "七"),
+    ]
+
+    @Test func rendersToAnImage() {
+        let renderer = ImageRenderer(content: CandidateListView(candidates: candidates, showsCode: true))
+        #expect(renderer.cgImage != nil)
+    }
+
+    @Test func codeColumnAddsWidth() {
+        let withCode = ImageRenderer(content: CandidateListView(candidates: candidates, showsCode: true)).cgImage
+        let withoutCode = ImageRenderer(content: CandidateListView(candidates: candidates, showsCode: false)).cgImage
+        let withCodeImage = try! #require(withCode)
+        let withoutCodeImage = try! #require(withoutCode)
+        // Showing the muted BSM code column makes each row wider.
+        #expect(withCodeImage.width > withoutCodeImage.width)
+    }
+
+    @Test func emptyListStillRenders() {
+        let renderer = ImageRenderer(content: CandidateListView(candidates: [], showsCode: true))
+        #expect(renderer.cgImage != nil)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -34,6 +34,8 @@ targets:
     dependencies:
       - package: BSMCore
         product: BSMCore
+      - package: BSMCore
+        product: BSMCandidateUI
     settings:
       base:
         PRODUCT_NAME: BSMInputMethod
@@ -42,3 +44,43 @@ targets:
         GENERATE_INFOPLIST_FILE: "NO"
         SKIP_INSTALL: "NO"
         ENABLE_HARDENED_RUNTIME: "YES"
+
+  BSMExample:
+    type: application
+    platform: macOS
+    sources:
+      - path: Example
+    dependencies:
+      - package: BSMCore
+        product: BSMCore
+      - package: BSMCore
+        product: BSMCandidateUI
+    settings:
+      base:
+        PRODUCT_NAME: BSMExample
+        PRODUCT_BUNDLE_IDENTIFIER: hk.ignition.inputmethod.BSMInputMethod.Example
+        INFOPLIST_FILE: Example/Info.plist
+        GENERATE_INFOPLIST_FILE: "NO"
+
+  BSMExampleUITests:
+    type: bundle.ui-testing
+    platform: macOS
+    sources:
+      - path: ExampleUITests
+    dependencies:
+      - target: BSMExample
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: "YES"
+        PRODUCT_BUNDLE_IDENTIFIER: hk.ignition.inputmethod.BSMInputMethod.ExampleUITests
+        TEST_TARGET_NAME: BSMExample
+
+schemes:
+  BSMExample:
+    build:
+      targets:
+        BSMExample: all
+        BSMExampleUITests: [test]
+    test:
+      targets:
+        - BSMExampleUITests


### PR DESCRIPTION
Implements #5 — the custom Candidate List that replaces `IMKCandidates` (ADR 0008), plus a standalone Example app for UI testing. **Stacked on #11.**

## What's here
- **`BSMCore`**: `Candidate` and `BSMCode` value types.
- **`BSMCandidateUI`** (shared library):
  - `CandidateListView` — numbered candidate rows with a toggleable **muted BSM code** column, with accessibility identifiers on every element.
  - `CandidateWindowController` — hosts the list in a non-activating borderless `NSPanel` via `NSHostingView`, positioned by top-left for caret-relative display.
- **`BSMExample`** — standalone macOS app driving the list from mock candidate pages, with **Toggle Code** / **Next Page** controls.
- **`ExampleUITests`** — XCUITest covering numbered rows, the word/code columns, the code toggle, and paging.
- **`BSMCandidateUITests`** — headless `ImageRenderer` tests.

## Verification
- `swift test` — render tests pass, asserting the code column changes layout (toggle works).
- `xcodebuild -scheme BSMExample build` — Example app **BUILD SUCCEEDED**.
- The XCUITests **build**, but running them needs an interactive login session with Automation permission — they time out headless ("enabling automation mode"). This is the **HITL** part of #5; please run them from a logged-in session / Xcode.

Refs ADR 0008.
