### PR TITLE
Candidate dictionary lookup in BSMCore (SQLite.swift behind protocol) (#6)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     products: [
         .library(name: "BSMCore", targets: ["BSMCore"]),
         .library(name: "BSMCandidateUI", targets: ["BSMCandidateUI"]),
+        .library(name: "BSMDictionarySQLite", targets: ["BSMDictionarySQLite"]),
         .executable(name: "bsm-db-build", targets: ["BSMDatabaseBuilder"]),
     ],
     dependencies: [
@@ -18,6 +19,16 @@ let package = Package(
 
         .target(name: "BSMCandidateUI", dependencies: ["BSMCore"]),
         .testTarget(name: "BSMCandidateUITests", dependencies: ["BSMCandidateUI", "BSMCore"]),
+
+        // SQLite.swift-backed dictionary, kept behind the BSMCore boundary.
+        .target(
+            name: "BSMDictionarySQLite",
+            dependencies: ["BSMCore", .product(name: "SQLite", package: "SQLite.swift")]
+        ),
+        .testTarget(
+            name: "BSMDictionarySQLiteTests",
+            dependencies: ["BSMDictionarySQLite", "BSMCore"]
+        ),
 
         // Database builder: pure logic lives in the library so it is testable;
         // the executable is a thin CLI entry point. (ADR 0005)

--- a/Sources/BSMCore/CandidateDictionary.swift
+++ b/Sources/BSMCore/CandidateDictionary.swift
@@ -1,0 +1,23 @@
+/// The lookup boundary owned by BSMCore (ADR 0003). Implementations resolve a
+/// BSM Code into candidate words; SQLite.swift (or any other backend) stays
+/// hidden behind this protocol so the rest of the system speaks only BSM
+/// concepts and tests can substitute an in-memory fake.
+public protocol CandidateDictionary {
+    /// Candidate words matching `code`, grouped by word, for the given page.
+    /// A `*` in the code is a wildcard.
+    func candidates(matching code: BSMCode, page: Int, pageSize: Int) throws -> [Candidate]
+
+    /// Number of distinct candidate words matching `code`.
+    func candidateCount(matching code: BSMCode) throws -> Int
+
+    /// The set of one-character extensions of `code` that still have at least
+    /// one match. Empty once the code reaches the 6-character limit.
+    func possibleNextCodes(after code: BSMCode) throws -> Set<BSMCode>
+}
+
+public extension CandidateDictionary {
+    /// Convenience for the default page size of 9 candidates.
+    func candidates(matching code: BSMCode, page: Int) throws -> [Candidate] {
+        try candidates(matching: code, page: page, pageSize: 9)
+    }
+}

--- a/Sources/BSMCore/InMemoryCandidateDictionary.swift
+++ b/Sources/BSMCore/InMemoryCandidateDictionary.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// A pure in-memory CandidateDictionary for behavior-parity tests (ADR 0003).
+///
+/// Reproduces the legacy lookup semantics without SQLite: prefix/wildcard
+/// matching via SQL-`LIKE` rules, grouping by word keeping the lowest row id,
+/// and ordering by code length then (for wildcard searches) frequency, else row
+/// id.
+public final class InMemoryCandidateDictionary: CandidateDictionary {
+    private struct Entry {
+        let id: Int
+        let code: String
+        let word: String
+        let frequency: Int
+    }
+
+    private let entries: [Entry]
+
+    public init(entries: [(code: String, word: String, frequency: Int)]) {
+        self.entries = entries.enumerated().map {
+            Entry(id: $0.offset, code: $0.element.code, word: $0.element.word, frequency: $0.element.frequency)
+        }
+    }
+
+    public func candidates(matching code: BSMCode, page: Int, pageSize: Int) throws -> [Candidate] {
+        let isWildcard = code.raw.contains("*")
+        var groups = Array(grouped(matching: code).values)
+        if isWildcard {
+            groups.sort { ($0.code.count, $0.frequency, $0.id) < ($1.code.count, $1.frequency, $1.id) }
+        } else {
+            groups.sort { ($0.code.count, $0.id) < ($1.code.count, $1.id) }
+        }
+        let offset = isWildcard ? page * pageSize : page * 9
+        guard offset < groups.count else { return [] }
+        return groups[offset..<min(offset + pageSize, groups.count)]
+            .map { Candidate(code: BSMCode($0.code), word: $0.word) }
+    }
+
+    public func candidateCount(matching code: BSMCode) throws -> Int {
+        grouped(matching: code).count
+    }
+
+    public func possibleNextCodes(after code: BSMCode) throws -> Set<BSMCode> {
+        guard code.raw.count < 6 else { return [] }
+        var result: Set<BSMCode> = []
+        for digit in "0123456789" {
+            let next = BSMCode(code.raw + String(digit))
+            if try candidateCount(matching: next) > 0 {
+                result.insert(next)
+            }
+        }
+        return result
+    }
+
+    private func grouped(matching code: BSMCode) -> [String: Entry] {
+        let pattern = Array(code.raw.replacingOccurrences(of: "*", with: "%") + "%")
+        let minLength = max(pattern.count - 1, 1)
+        var byWord: [String: Entry] = [:]
+        for entry in entries where entry.code.count >= minLength
+            && Self.likeMatch(pattern, Array(entry.code)) {
+            if let existing = byWord[entry.word] {
+                if entry.id < existing.id { byWord[entry.word] = entry }
+            } else {
+                byWord[entry.word] = entry
+            }
+        }
+        return byWord
+    }
+
+    /// SQL `LIKE` matching for patterns containing the `%` multi-character
+    /// wildcard (the only wildcard BSM codes produce).
+    static func likeMatch(_ pattern: [Character], _ text: [Character]) -> Bool {
+        var p = 0, t = 0, star = -1, mark = 0
+        while t < text.count {
+            if p < pattern.count, pattern[p] == "%" {
+                star = p; mark = t; p += 1
+            } else if p < pattern.count, pattern[p] == text[t] {
+                p += 1; t += 1
+            } else if star != -1 {
+                p = star + 1; mark += 1; t = mark
+            } else {
+                return false
+            }
+        }
+        while p < pattern.count, pattern[p] == "%" { p += 1 }
+        return p == pattern.count
+    }
+}

--- a/Sources/BSMDictionarySQLite/SQLiteCandidateDictionary.swift
+++ b/Sources/BSMDictionarySQLite/SQLiteCandidateDictionary.swift
@@ -1,0 +1,79 @@
+import Foundation
+import SQLite
+import BSMCore
+
+/// SQLite.swift-backed CandidateDictionary over the bundled `bsm.db`,
+/// reproducing the legacy `BSMEngine` query semantics (ADR 0003, ADR 0004).
+///
+/// The database is opened read-only. SQLite.swift types never escape this type;
+/// callers see only BSMCore concepts.
+public final class SQLiteCandidateDictionary: CandidateDictionary {
+    private let db: Connection
+
+    public init(databasePath: String) throws {
+        db = try Connection(databasePath, readonly: true)
+    }
+
+    init(connection: Connection) {
+        db = connection
+    }
+
+    /// In-memory dictionary seeded with the given rows; used by tests.
+    public static func inMemory(rows: [(code: String, word: String, frequency: Int)]) throws -> SQLiteCandidateDictionary {
+        let db = try Connection(.inMemory)
+        try db.execute("CREATE TABLE ime (id integer primary key autoincrement, code char(6), word char(1), frequency integer default 6000);")
+        let insert = try db.prepare("INSERT INTO ime (code, word, frequency) VALUES (?, ?, ?)")
+        for row in rows { try insert.run(row.code, row.word, row.frequency) }
+        return SQLiteCandidateDictionary(connection: db)
+    }
+
+    public func candidates(matching code: BSMCode, page: Int, pageSize: Int) throws -> [Candidate] {
+        let (like, minLength) = Self.likeFilter(for: code)
+        let sql: String
+        let offset: Int
+        if code.raw.contains("*") {
+            // Wildcard searches order by code length then frequency.
+            sql = "SELECT word, code, min(id) AS minid FROM ime WHERE code LIKE ? AND length(code) >= ? GROUP BY word ORDER BY length(code), frequency LIMIT ? OFFSET ?"
+            offset = page * pageSize
+        } else {
+            // Non-wildcard searches order by code length then original row order.
+            // The legacy offset multiplier is a fixed 9, preserved for parity.
+            sql = "SELECT word, code, min(id) AS minid FROM ime WHERE code LIKE ? AND length(code) >= ? GROUP BY word ORDER BY length(code), minid LIMIT ? OFFSET ?"
+            offset = page * 9
+        }
+
+        var results: [Candidate] = []
+        for row in try db.prepare(sql, like, minLength, pageSize, offset) {
+            let word = row[0] as! String
+            let storedCode = row[1] as! String
+            results.append(Candidate(code: BSMCode(storedCode), word: word))
+        }
+        return results
+    }
+
+    public func candidateCount(matching code: BSMCode) throws -> Int {
+        let (like, minLength) = Self.likeFilter(for: code)
+        let sql = "SELECT count(*) FROM (SELECT word FROM ime WHERE code LIKE ? AND length(code) >= ? GROUP BY word)"
+        return Int(try db.scalar(sql, like, minLength) as! Int64)
+    }
+
+    public func possibleNextCodes(after code: BSMCode) throws -> Set<BSMCode> {
+        guard code.raw.count < 6 else { return [] }
+        var result: Set<BSMCode> = []
+        for digit in "0123456789" {
+            let next = BSMCode(code.raw + String(digit))
+            if try candidateCount(matching: next) > 0 {
+                result.insert(next)
+            }
+        }
+        return result
+    }
+
+    /// Builds the `LIKE` pattern and minimum code length, mirroring the legacy
+    /// engine: replace `*` with `%`, append a trailing `%`, and require the
+    /// stored code to be at least one shorter than the pattern.
+    static func likeFilter(for code: BSMCode) -> (like: String, minLength: Int) {
+        let like = code.raw.replacingOccurrences(of: "*", with: "%") + "%"
+        return (like, max(like.count - 1, 1))
+    }
+}

--- a/Tests/BSMDictionarySQLiteTests/SQLiteCandidateDictionaryTests.swift
+++ b/Tests/BSMDictionarySQLiteTests/SQLiteCandidateDictionaryTests.swift
@@ -1,0 +1,122 @@
+import Testing
+import Foundation
+import BSMCore
+@testable import BSMDictionarySQLite
+
+private let repoRoot = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+
+private func dictionary() throws -> SQLiteCandidateDictionary {
+    try SQLiteCandidateDictionary(databasePath: repoRoot.appendingPathComponent("Data/bsm.db").path)
+}
+
+private func words(_ candidates: [Candidate]) -> [String] { candidates.map(\.word) }
+
+/// Ports BSMEngineSpec against the committed bsm.db.
+struct SQLiteCandidateDictionaryTests {
+    @Test(arguments: [
+        ("121", "工"), ("53", "刀"), ("32562", "他"), ("301453", "的"),
+    ])
+    func matchesExactCode(code: String, word: String) throws {
+        let result = try dictionary().candidates(matching: BSMCode(code), page: 0)
+        #expect(result.contains(Candidate(code: BSMCode(code), word: word)))
+    }
+
+    @Test func returnsAtMostNinePerPage() throws {
+        #expect(try dictionary().candidates(matching: BSMCode("1"), page: 0).count <= 9)
+    }
+
+    @Test func honorsRequestedPageSize() throws {
+        #expect(try dictionary().candidates(matching: BSMCode("1"), page: 0, pageSize: 20).count == 20)
+    }
+
+    @Test func firstCandidateForCode4IsExpected() throws {
+        let first = try #require(try dictionary().candidates(matching: BSMCode("4"), page: 0).first)
+        #expect(first.word == "這")
+    }
+
+    @Test func wildcardFindsDeepMatchAcrossPages() throws {
+        let dict = try dictionary()
+        let count = try dict.candidateCount(matching: BSMCode("325*2"))
+        #expect(count >= 1)
+        let pages = Int(ceil(Double(count) / 9.0))
+        var found = false
+        for page in 0..<pages where try dict.candidates(matching: BSMCode("325*2"), page: page)
+            .contains(Candidate(code: BSMCode("32562"), word: "他")) {
+            found = true
+        }
+        #expect(found)
+    }
+
+    @Test func wildcardExcludesShorterCode() throws {
+        let dict = try dictionary()
+        let count = try dict.candidateCount(matching: BSMCode("325*2"))
+        let pages = Int(ceil(Double(count) / 9.0))
+        var found = false
+        for page in 0..<pages where try dict.candidates(matching: BSMCode("325*2"), page: page)
+            .contains(Candidate(code: BSMCode("3252"), word: "師")) {
+            found = true
+        }
+        #expect(!found)
+    }
+
+    @Test func wildcardOrdersByFrequency() throws {
+        let result = try dictionary().candidates(matching: BSMCode("1*8"), page: 0)
+        #expect(result.contains(Candidate(code: BSMCode("118"), word: "天")))
+    }
+
+    @Test func paginationFillsEveryPageButTheLast() throws {
+        let dict = try dictionary()
+        let count = try dict.candidateCount(matching: BSMCode("122"))
+        let pages = Int(ceil(Double(count) / 9.0))
+        var collected = 0
+        for page in 0..<pages {
+            let pageResult = try dict.candidates(matching: BSMCode("122"), page: page)
+            if page + 1 < pages { #expect(pageResult.count == 9) }
+            collected += pageResult.count
+        }
+        #expect(collected == count)
+    }
+
+    @Test(arguments: [("99991", 2), ("11119", 1), ("11119111", 0)])
+    func countsDistinctMatches(code: String, expected: Int) throws {
+        #expect(try dictionary().candidateCount(matching: BSMCode(code)) == expected)
+    }
+
+    @Test func possibleNextCodesMatchesLegacy() throws {
+        let next = try dictionary().possibleNextCodes(after: BSMCode("118"))
+        for digit in ["1", "2", "4", "6", "8", "9", "0"] {
+            #expect(next.contains(BSMCode("118" + digit)))
+        }
+        for digit in ["3", "5", "7"] {
+            #expect(!next.contains(BSMCode("118" + digit)))
+        }
+    }
+
+    @Test func possibleNextCodesEmptyAtMaxLength() throws {
+        #expect(try dictionary().possibleNextCodes(after: BSMCode("123456")).isEmpty)
+    }
+
+    /// The pure in-memory fake (used by buffer tests) must agree with the SQLite
+    /// engine on identical data, so it is a trustworthy substitute.
+    @Test func inMemoryFakeAgreesWithSQLite() throws {
+        let rows: [(code: String, word: String, frequency: Int)] = [
+            ("1", "一", 3), ("1", "不", 2), ("11", "二", 50), ("118", "天", 9),
+            ("128", "夫", 40), ("12", "下", 7), ("121", "工", 103), ("13", "万", 60),
+        ]
+        let fake = InMemoryCandidateDictionary(entries: rows)
+        let sqlite = try SQLiteCandidateDictionary.inMemory(rows: rows)
+
+        for code in ["1", "12", "1*8", "118", "9"] {
+            let bsm = BSMCode(code)
+            #expect(try words(fake.candidates(matching: bsm, page: 0))
+                == words(sqlite.candidates(matching: bsm, page: 0)))
+            #expect(try fake.candidateCount(matching: bsm)
+                == sqlite.candidateCount(matching: bsm))
+        }
+        #expect(try fake.possibleNextCodes(after: BSMCode("1"))
+            == sqlite.possibleNextCodes(after: BSMCode("1")))
+    }
+}


### PR DESCRIPTION
Implements #6 — the candidate dictionary lookup boundary and its SQLite implementation (ADR 0003, 0004). **Stacked on #12.**

## What's here
- **`BSMCore`**:
  - `CandidateDictionary` protocol — `candidates(matching:page:pageSize:)`, `candidateCount(matching:)`, `possibleNextCodes(after:)`, all in BSM terms (no SQLite symbols).
  - `InMemoryCandidateDictionary` — a pure fake with SQL-`LIKE` matching, keeping `BSMCore` dependency-free.
- **`BSMDictionarySQLite`** (separate target so `BSMCore` stays pure):
  - `SQLiteCandidateDictionary` opens `bsm.db` read-only and reproduces the legacy `BSMEngine` SQL **exactly** — exact + `*` wildcard match, group-by-word, distinct counts, ordering (length then min id; wildcard: length then frequency), and possible-next-codes.

## TDD / verification
`swift test` (21 total) — the dictionary suite **ports `BSMEngineSpec`** against the committed `bsm.db`:
- exact matches (121→工, 53→刀, 32562→他, 301453→的); `match("4")` first word 這;
- wildcard `325*2` finds 32562 but never the shorter 3252; `1*8` ordered so 天 is on page 0;
- pagination fills every page but the last; counts (99991→2, 11119→1, 11119111→0);
- `possibleNextCodes("118")` matches the legacy allow/deny digit sets.

Plus a test that the in-memory fake **agrees with the SQLite engine** on identical data, so #7's buffer tests can trust the fake.

Refs ADR 0003, 0004.
