### PR TITLE
ComposingBuffer parity behavior in BSMCore (#7)

### DIFF
--- a/Sources/BSMCore/ComposingBuffer.swift
+++ b/Sources/BSMCore/ComposingBuffer.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+/// The Composing Buffer: the transient state for a single conversion.
+///
+/// Holds the BSM Code (lookup string of stroke digits plus the `*` wildcard,
+/// max 6, excluding `.`) and the Stroke Marker (display glyphs), tracks
+/// Selection Mode and paging, and stages a Composed String. Mirrors the legacy
+/// `BSMBuffer`: candidate lookups are lazy and run on the main actor (ADR 0010).
+@MainActor
+public final class ComposingBuffer {
+    /// Maximum length of the BSM Code (the `.` trigger does not count).
+    public static let maxCodeLength = 6
+
+    private static let markerGlyphs: [Character: Character] = [
+        "1": "一", "2": "丨", "3": "丿", "4": "丶", "5": "亅",
+        "6": "𠄌", "7": "乂", "8": "八", "9": "十", "0": "囗",
+    ]
+
+    private let dictionary: CandidateDictionary
+    private var needsUpdate = false
+    private var cachedCandidates: [Candidate] = []
+    private var cachedComposedString = ""
+
+    /// The BSM Code accumulated so far.
+    public private(set) var code = BSMCode("")
+    /// The Stroke Marker shown as marked text.
+    public private(set) var marker = ""
+    /// Whether the buffer is in Selection Mode (entered by typing `.`).
+    public private(set) var isSelecting = false
+    /// Total number of candidate pages. Settable to mirror the legacy buffer.
+    public var numberOfPage = 0
+    /// The current candidate page.
+    public private(set) var currentPage = 0
+
+    public init(dictionary: CandidateDictionary) {
+        self.dictionary = dictionary
+    }
+
+    public var isEmpty: Bool { code.raw.isEmpty }
+
+    /// Whether the BSM Code has reached the maximum length.
+    public var isCodeFull: Bool { code.raw.count >= Self.maxCodeLength }
+
+    /// Append one input character. `.` enters Selection Mode and only extends
+    /// the Stroke Marker; digits and `*` extend the BSM Code. Returns `false`
+    /// when the input is rejected (unknown character, or the code is full).
+    @discardableResult
+    public func append(_ input: String) -> Bool {
+        guard input.count == 1, let character = input.first else { return false }
+
+        if character == "." {
+            marker.append(".")
+            isSelecting = true
+            return true
+        }
+
+        let glyph: Character
+        if character == "*" {
+            glyph = "*"
+        } else if let mapped = Self.markerGlyphs[character] {
+            glyph = mapped
+        } else {
+            return false
+        }
+
+        guard !isCodeFull else { return false }
+        marker.append(glyph)
+        code = BSMCode(code.raw + String(character))
+        needsUpdate = true
+        return true
+    }
+
+    /// Remove the last Stroke Marker step. Removing the `.` exits Selection
+    /// Mode; otherwise one character is removed from the BSM Code too.
+    public func deleteBackward() {
+        guard let last = marker.last else { return }
+        if last == "." {
+            isSelecting = false
+        } else {
+            code = BSMCode(String(code.raw.dropLast()))
+            needsUpdate = true
+        }
+        marker.removeLast()
+    }
+
+    /// Replace the Composed String with the candidate at `index`, only while in
+    /// Selection Mode. Returns whether a selection was made.
+    @discardableResult
+    public func setSelectedIndex(_ index: Int) throws -> Bool {
+        let candidates = try candidates()
+        guard isSelecting, index >= 0, index < candidates.count else { return false }
+        cachedComposedString = candidates[index].word
+        return true
+    }
+
+    /// Advance to the next page, wrapping to the first. Returns `true` on wrap.
+    @discardableResult
+    public func nextPage() -> Bool {
+        let wrapped: Bool
+        if currentPage + 1 < numberOfPage {
+            currentPage += 1
+            wrapped = false
+        } else {
+            currentPage = 0
+            wrapped = true
+        }
+        needsUpdate = true
+        return wrapped
+    }
+
+    /// Go to the previous page, wrapping to the last. Returns `true` on wrap.
+    @discardableResult
+    public func previousPage() -> Bool {
+        let wrapped: Bool
+        if currentPage > 0 {
+            currentPage -= 1
+            wrapped = false
+        } else {
+            currentPage = max(numberOfPage - 1, 0)
+            wrapped = true
+        }
+        needsUpdate = true
+        return wrapped
+    }
+
+    public func reset() {
+        code = BSMCode("")
+        marker = ""
+        isSelecting = false
+        currentPage = 0
+        numberOfPage = 0
+        cachedCandidates = []
+        cachedComposedString = ""
+        needsUpdate = false
+    }
+
+    /// The candidate list for the current code and page (lazily recomputed).
+    public func candidates() throws -> [Candidate] {
+        try reloadIfNeeded()
+        return cachedCandidates
+    }
+
+    /// The Composed String staged for commit (lazily recomputed).
+    public func composedString() throws -> String {
+        try reloadIfNeeded()
+        return cachedComposedString
+    }
+
+    /// The possible next codes: all ten digits when empty, otherwise the codes
+    /// that still have a match.
+    public func possibleNextCodes() throws -> Set<BSMCode> {
+        if isEmpty {
+            return Set("0123456789".map { BSMCode(String($0)) })
+        }
+        return try dictionary.possibleNextCodes(after: code)
+    }
+
+    private func reloadIfNeeded() throws {
+        guard needsUpdate else { return }
+        needsUpdate = false
+        if code.raw.isEmpty {
+            numberOfPage = 1
+            cachedCandidates = []
+            cachedComposedString = ""
+            return
+        }
+        let count = try dictionary.candidateCount(matching: code)
+        numberOfPage = Int(ceil(Double(count) / 9.0))
+        cachedCandidates = try dictionary.candidates(matching: code, page: currentPage)
+        cachedComposedString = cachedCandidates.first?.word ?? ""
+    }
+}

--- a/Tests/BSMCoreTests/ComposingBufferTests.swift
+++ b/Tests/BSMCoreTests/ComposingBufferTests.swift
@@ -1,0 +1,144 @@
+import Testing
+@testable import BSMCore
+
+@MainActor
+struct ComposingBufferTests {
+    private func makeBuffer(_ entries: [(code: String, word: String, frequency: Int)] = []) -> ComposingBuffer {
+        ComposingBuffer(dictionary: InMemoryCandidateDictionary(entries: entries))
+    }
+
+    @Test func initialState() throws {
+        let buffer = makeBuffer()
+        #expect(try buffer.composedString() == "")
+        #expect(buffer.marker == "")
+        #expect(try buffer.candidates() == [])
+    }
+
+    @Test func appendMapsMarkerGlyphs() {
+        let buffer = makeBuffer()
+        buffer.append("1")
+        #expect(buffer.marker == "一")
+        buffer.append("2")
+        #expect(buffer.marker == "一丨")
+    }
+
+    @Test func decimalEntersSelectionMode() {
+        let buffer = makeBuffer()
+        buffer.append("1")
+        buffer.append("2")
+        #expect(buffer.isSelecting == false)
+        buffer.append(".")
+        #expect(buffer.isSelecting)
+        #expect(buffer.marker == "一丨.")
+    }
+
+    @Test func deleteUpdatesMarker() {
+        let buffer = makeBuffer()
+        buffer.append("1")
+        buffer.append("2")
+        #expect(buffer.marker == "一丨")
+        buffer.deleteBackward()
+        #expect(buffer.marker == "一")
+    }
+
+    @Test func deleteExitsSelectionMode() {
+        let buffer = makeBuffer()
+        buffer.append("1")
+        buffer.append("2")
+        buffer.append(".")
+        #expect(buffer.isSelecting)
+        buffer.deleteBackward()
+        #expect(buffer.isSelecting == false)
+    }
+
+    @Test func appendSixThenDeleteTwice() {
+        let buffer = makeBuffer()
+        for character in ["6", "6", "4", "6", "6", "4"] { buffer.append(character) }
+        buffer.deleteBackward()
+        #expect(buffer.code.raw == "66466")
+        #expect(buffer.marker == "𠄌𠄌丶𠄌𠄌")
+        buffer.deleteBackward()
+        #expect(buffer.code.raw == "6646")
+        #expect(buffer.marker == "𠄌𠄌丶𠄌")
+    }
+
+    @Test func enforcesMaxCodeLength() {
+        let buffer = makeBuffer()
+        for _ in 0..<6 { #expect(buffer.append("1")) }
+        #expect(buffer.isCodeFull)
+        #expect(buffer.append("1") == false)
+        #expect(buffer.code.raw == "111111")
+    }
+
+    @Test func wildcardExtendsCodeAndMarker() {
+        let buffer = makeBuffer()
+        buffer.append("1")
+        buffer.append("*")
+        buffer.append("8")
+        #expect(buffer.code.raw == "1*8")
+        #expect(buffer.marker == "一*八")
+    }
+
+    @Test func isEmptyReflectsCode() {
+        let buffer = makeBuffer()
+        #expect(buffer.isEmpty)
+        buffer.append("1")
+        #expect(buffer.isEmpty == false)
+        buffer.deleteBackward()
+        #expect(buffer.isEmpty)
+    }
+
+    @Test func nextPageWraps() {
+        let buffer = makeBuffer()
+        buffer.numberOfPage = 3
+        #expect(buffer.currentPage == 0)
+        #expect(buffer.nextPage() == false)
+        #expect(buffer.currentPage == 1)
+        #expect(buffer.nextPage() == false)
+        #expect(buffer.currentPage == 2)
+        #expect(buffer.nextPage())
+        #expect(buffer.currentPage == 0)
+    }
+
+    @Test func previousPageWraps() {
+        let buffer = makeBuffer()
+        buffer.numberOfPage = 3
+        #expect(buffer.currentPage == 0)
+        #expect(buffer.previousPage())
+        #expect(buffer.currentPage == 2)
+        #expect(buffer.previousPage() == false)
+        #expect(buffer.currentPage == 1)
+        #expect(buffer.previousPage() == false)
+        #expect(buffer.currentPage == 0)
+    }
+
+    @Test func possibleNextCodesWhenEmptyReturnsAllDigits() throws {
+        let buffer = makeBuffer()
+        let next = try buffer.possibleNextCodes()
+        #expect(next == Set("0123456789".map { BSMCode(String($0)) }))
+    }
+
+    @Test func possibleNextCodesDelegatesToDictionary() throws {
+        let buffer = makeBuffer([("12", "x", 1), ("13", "y", 1)])
+        buffer.append("1")
+        let next = try buffer.possibleNextCodes()
+        #expect(next.contains(BSMCode("12")))
+        #expect(next.contains(BSMCode("13")))
+        #expect(!next.contains(BSMCode("19")))
+    }
+
+    @Test func setSelectedIndexChoosesCandidateInSelectionMode() throws {
+        let buffer = makeBuffer([("1", "甲", 1), ("1", "乙", 2)])
+        buffer.append("1")
+        buffer.append(".")
+        #expect(try buffer.candidates().count == 2)
+        #expect(try buffer.setSelectedIndex(1))
+        #expect(try buffer.composedString() == "乙")
+    }
+
+    @Test func setSelectedIndexIgnoredOutsideSelectionMode() throws {
+        let buffer = makeBuffer([("1", "甲", 1)])
+        buffer.append("1")
+        #expect(try buffer.setSelectedIndex(0) == false)
+    }
+}

--- a/Tests/BSMDictionarySQLiteTests/ComposingBufferIntegrationTests.swift
+++ b/Tests/BSMDictionarySQLiteTests/ComposingBufferIntegrationTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import Foundation
+import BSMCore
+import BSMDictionarySQLite
+
+/// Drives the ComposingBuffer against the real bsm.db, porting the legacy
+/// BSMBufferSpec "-candidates" case.
+@MainActor
+struct ComposingBufferIntegrationTests {
+    private func makeBuffer() throws -> ComposingBuffer {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let dictionary = try SQLiteCandidateDictionary(databasePath: root.appendingPathComponent("Data/bsm.db").path)
+        return ComposingBuffer(dictionary: dictionary)
+    }
+
+    @Test func producesProperCandidates() throws {
+        let buffer = try makeBuffer()
+        for character in ["9", "9", "1", "9"] { buffer.append(character) }
+        #expect(try buffer.candidates().count == 9)
+
+        buffer.append("1")
+        #expect(try buffer.candidates().count == 4)
+        #expect(try buffer.composedString() == "茸")
+    }
+}


### PR DESCRIPTION
Implements #7 — the `ComposingBuffer` parity state machine (ADR 0001, 0010). **Stacked on #13.**

## What's here
`BSMCore.ComposingBuffer`, a main-actor port of the legacy `BSMBuffer`:
- Tracks the **BSM Code** and **Stroke Marker** separately, with the stroke-glyph mapping (`1→一 … 6→𠄌 … 0→囗`).
- `.` enters **Selection Mode** and extends only the marker; `*` is a wildcard extending both; the **6-character limit** applies to the BSM Code (the `.` doesn't count).
- `deleteBackward` removes one marker step and exits Selection Mode when removing `.`; paging **wraps**; candidates and the **Composed String** are computed lazily via the `CandidateDictionary`.

## TDD / verification
`swift test` (37 total). Buffer suite ports `BSMBufferSpec` with the in-memory fake:
- marker mapping; `.`→selection mode; the 6-char append-then-delete-twice case (`66466`/`𠄌𠄌丶𠄌𠄌`); wildcard `1*8`; max-length rejection; `isEmpty`; next/previous page wrap; `possibleNextCodes` (all digits when empty, else delegated); `setSelectedIndex`.
- A **real-`bsm.db` integration test** reproduces the spec's candidate case: `9919` → 9 candidates, `99191` → 4, Composed String `茸`.

Refs ADR 0001, 0010.
