### PR TITLE
End-to-end IME integration (full behavior parity) (#8)

### DIFF
--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -1,30 +1,222 @@
 import Cocoa
+import Carbon.HIToolbox
 import InputMethodKit
+import BSMCore
+import BSMCandidateUI
 
-/// Walking-skeleton input controller.
-///
-/// This proves the InputMethodKit plumbing end-to-end: it loads from the
-/// `InputMethodServerControllerClass` declared in Info.plist (the
-/// module-namespaced `BSMInputMethod.InputController`), receives key events,
-/// and echoes numeric-keypad input straight into the client. Real BSM
-/// composition, the Candidate Dictionary, and the Candidate List arrive in
-/// later slices.
+/// The BSM input controller. Routes numeric-keypad events into the Composing
+/// Buffer, drives marked text and the Candidate List, and commits the Composed
+/// String — reproducing the legacy `BSMInputMethodController` behavior (ADR
+/// 0009, 0010). Loaded by IMK as `BSMInputMethod.InputController`.
 @MainActor
 final class InputController: IMKInputController {
-    override func inputText(
-        _ string: String!,
-        key keyCode: Int,
-        modifiers flags: Int,
-        client sender: Any!
-    ) -> Bool {
-        guard let client = sender as? IMKTextInput else { return false }
+    private let buffer = ComposingBuffer(dictionary: SharedServices.dictionary)
+    private var candidateWindow: CandidateWindowController { SharedServices.candidateWindow }
+    private var showsCode = true
+    private weak var currentClient: (any IMKTextInput)?
 
-        // Only handle the numeric keypad; let every other key fall through to
-        // the system so normal typing is unaffected.
-        let isKeypad = (flags & Int(NSEvent.ModifierFlags.numericPad.rawValue)) != 0
-        guard isKeypad, let text = string, !text.isEmpty else { return false }
+    override func inputText(_ string: String!, key keyCode: Int, modifiers flags: Int, client sender: Any!) -> Bool {
+        guard let client = sender as? any IMKTextInput else { return false }
+        currentClient = client
+        do {
+            return try handle(string ?? "", keyCode: keyCode, client: client)
+        } catch {
+            return false
+        }
+    }
 
-        client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+    private func handle(_ string: String, keyCode: Int, client: any IMKTextInput) throws -> Bool {
+        switch keyCode {
+        case kVK_ANSI_KeypadDecimal:
+            guard !buffer.isEmpty else { return false }
+            if buffer.isSelecting {
+                return try selectFirstCandidate(client)
+            } else {
+                return try appendBuffer(string, client: client)
+            }
+
+        case kVK_ANSI_Keypad0...kVK_ANSI_Keypad9, kVK_ANSI_KeypadMultiply:
+            if buffer.isSelecting, keyCode != kVK_ANSI_KeypadMultiply {
+                guard keyCode > kVK_ANSI_Keypad0 else { beep(); return true }
+                if try buffer.setSelectedIndex(selectionIndex(for: keyCode)) {
+                    commit(client)
+                } else {
+                    beep()
+                }
+                return true
+            } else if !buffer.isCodeFull {
+                return try appendBuffer(string, client: client)
+            } else {
+                beep()
+                return true
+            }
+
+        case kVK_ANSI_KeypadMinus:
+            return try minusBuffer(client)
+
+        case kVK_ANSI_KeypadPlus:
+            guard !buffer.isEmpty else { return false }
+            showsCode.toggle()
+            candidateWindow.setShowsCode(showsCode)
+            return true
+
+        case kVK_ANSI_KeypadEnter, kVK_Space:
+            guard !buffer.isEmpty else { return false }
+            if try !buffer.composedString().isEmpty {
+                return try selectFirstCandidate(client)
+            } else {
+                beep()
+                return true
+            }
+
+        case kVK_ANSI_KeypadDivide:
+            guard !buffer.isEmpty else { return false }
+            if buffer.nextPage() { beep() }
+            try showCandidateWindow(client)
+            return true
+
+        case kVK_ANSI_KeypadEquals:
+            guard !buffer.isEmpty else { return false }
+            if buffer.previousPage() { beep() }
+            try showCandidateWindow(client)
+            return true
+
+        case kVK_ANSI_KeypadClear:
+            clearInput(client)
+            return true
+
+        default:
+            return false
+        }
+    }
+
+    /// Keypad digit key codes are contiguous for 1...7 but not 8/9.
+    private func selectionIndex(for keyCode: Int) -> Int {
+        switch keyCode {
+        case kVK_ANSI_Keypad1...kVK_ANSI_Keypad7: return keyCode - kVK_ANSI_Keypad1
+        case kVK_ANSI_Keypad8: return 7
+        case kVK_ANSI_Keypad9: return 8
+        default: return 0
+        }
+    }
+
+    private func appendBuffer(_ string: String, client: any IMKTextInput) throws -> Bool {
+        currentClient = client
+        buffer.append(string)
+        updateMarkedText(client)
+        try showCandidateWindow(client)
         return true
+    }
+
+    private func minusBuffer(_ client: any IMKTextInput) throws -> Bool {
+        currentClient = client
+        guard !buffer.isEmpty else { return false }
+        buffer.deleteBackward()
+        updateMarkedText(client)
+        if try !buffer.composedString().isEmpty {
+            try showCandidateWindow(client)
+        } else {
+            candidateWindow.hide()
+        }
+        return true
+    }
+
+    private func selectFirstCandidate(_ client: any IMKTextInput) throws -> Bool {
+        if try !buffer.candidates().isEmpty, try !buffer.composedString().isEmpty {
+            commit(client)
+        } else {
+            beep()
+        }
+        return true
+    }
+
+    private func updateMarkedText(_ client: any IMKTextInput) {
+        let marker = buffer.marker
+        client.setMarkedText(
+            attributedMarker(marker),
+            selectionRange: NSRange(location: marker.utf16.count, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: NSNotFound)
+        )
+    }
+
+    private func attributedMarker(_ string: String) -> NSAttributedString {
+        let range = NSRange(location: 0, length: string.utf16.count)
+        let attributes = mark(forStyle: kTSMHiliteRawText, at: range) as? [NSAttributedString.Key: Any]
+        return NSAttributedString(string: string, attributes: attributes)
+    }
+
+    private func clearInput(_ client: any IMKTextInput) {
+        client.setMarkedText(
+            "",
+            selectionRange: NSRange(location: NSNotFound, length: NSNotFound),
+            replacementRange: NSRange(location: NSNotFound, length: NSNotFound)
+        )
+        buffer.reset()
+        cancelComposition()
+        candidateWindow.hide()
+    }
+
+    private func commit(_ client: any IMKTextInput) {
+        // Work around the premature-commit issue in Terminal: defer marked text
+        // instead of inserting (matches the legacy controller).
+        if client.bundleIdentifier() == "com.apple.Terminal",
+           String(describing: type(of: client)) != "IPMDServerClientWrapper" {
+            DispatchQueue.main.async { [weak self] in self?.updateMarkedText(client) }
+            return
+        }
+        let composed = (try? buffer.composedString()) ?? ""
+        client.insertText(composed, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+        buffer.reset()
+        candidateWindow.hide()
+    }
+
+    override func commitComposition(_ sender: Any!) {
+        guard let client = sender as? any IMKTextInput else { return }
+        commit(client)
+    }
+
+    override func cancelComposition() {
+        super.cancelComposition()
+        buffer.reset()
+        candidateWindow.hide()
+    }
+
+    override func deactivateServer(_ sender: Any!) {
+        if !buffer.isEmpty {
+            buffer.reset()
+            (sender as? any IMKTextInput)?.setMarkedText(
+                "",
+                selectionRange: NSRange(location: 0, length: 0),
+                replacementRange: NSRange(location: NSNotFound, length: NSNotFound)
+            )
+        }
+        candidateWindow.hide()
+        currentClient = nil
+    }
+
+    private func showCandidateWindow(_ client: any IMKTextInput) throws {
+        let candidates = try buffer.candidates()
+        guard !candidates.isEmpty else {
+            candidateWindow.hide()
+            return
+        }
+
+        var lineRect = NSRect(x: 0, y: 0, width: 16, height: 16)
+        var cursorIndex = selectionRange().location
+        if cursorIndex == buffer.marker.utf16.count, cursorIndex > 0 {
+            cursorIndex -= 1
+        }
+        _ = client.attributes(forCharacterIndex: cursorIndex, lineHeightRectangle: &lineRect)
+
+        candidateWindow.display(
+            candidates: candidates,
+            showsCode: showsCode,
+            selectedIndex: nil,
+            caretRect: lineRect
+        )
+    }
+
+    private func beep() {
+        NSSound.beep()
     }
 }

--- a/App/SharedServices.swift
+++ b/App/SharedServices.swift
@@ -1,0 +1,22 @@
+import Foundation
+import BSMCore
+import BSMCandidateUI
+import BSMDictionarySQLite
+
+/// Process-wide services shared by every input session: the read-only candidate
+/// dictionary over the bundled `bsm.db`, and the single Candidate List window.
+@MainActor
+enum SharedServices {
+    static let dictionary: CandidateDictionary = {
+        guard let path = Bundle.main.path(forResource: "bsm", ofType: "db") else {
+            fatalError("bsm.db missing from the app bundle")
+        }
+        do {
+            return try SQLiteCandidateDictionary(databasePath: path)
+        } catch {
+            fatalError("Failed to open bsm.db: \(error)")
+        }
+    }()
+
+    static let candidateWindow = CandidateWindowController()
+}

--- a/Sources/BSMCandidateUI/CandidateWindowController.swift
+++ b/Sources/BSMCandidateUI/CandidateWindowController.swift
@@ -2,13 +2,19 @@ import AppKit
 import SwiftUI
 import BSMCore
 
-/// Hosts the Candidate List in a borderless `NSPanel` positioned by the input
-/// controller near the caret (ADR 0008). The panel is non-activating so it does
-/// not steal key focus from the client application.
+/// Hosts the Candidate List in a borderless `NSPanel` positioned near the caret
+/// (ADR 0008). The panel is non-activating so it does not steal key focus from
+/// the client application.
 @MainActor
 public final class CandidateWindowController {
     private let panel: NSPanel
     private let hostingView: NSHostingView<CandidateListView>
+
+    private var candidates: [Candidate] = []
+    private var selectedIndex: Int?
+
+    /// Whether the muted BSM code column is shown (toggled by `+`).
+    public private(set) var showsCode = true
 
     public init() {
         hostingView = NSHostingView(rootView: CandidateListView(candidates: [], showsCode: true))
@@ -28,30 +34,39 @@ public final class CandidateWindowController {
 
     public var isVisible: Bool { panel.isVisible }
 
-    /// Replace the displayed candidates and resize the panel to fit.
-    public func update(candidates: [Candidate], showsCode: Bool, selectedIndex: Int?) {
-        hostingView.rootView = CandidateListView(
-            candidates: candidates,
-            showsCode: showsCode,
-            selectedIndex: selectedIndex
-        )
-        panel.setContentSize(hostingView.fittingSize)
-    }
+    /// Show the candidates positioned relative to the caret's line-height
+    /// rectangle (in screen coordinates), nudging back on-screen as needed.
+    public func display(candidates: [Candidate], showsCode: Bool, selectedIndex: Int?, caretRect: NSRect) {
+        self.candidates = candidates
+        self.showsCode = showsCode
+        self.selectedIndex = selectedIndex
+        render()
 
-    /// Show the panel with its top-left corner at `topLeft` in screen coordinates,
-    /// nudging it back on-screen if it would overflow the bottom edge.
-    public func show(topLeft: NSPoint) {
-        panel.setContentSize(hostingView.fittingSize)
-        var origin = NSPoint(x: topLeft.x, y: topLeft.y - panel.frame.height)
+        var origin = NSPoint(x: caretRect.minX, y: caretRect.minY - panel.frame.height - 4)
         if let visible = NSScreen.main?.visibleFrame {
-            if origin.y < visible.minY { origin.y = topLeft.y }
+            if origin.y < visible.minY { origin.y = caretRect.maxY + 4 }
             origin.x = min(origin.x, visible.maxX - panel.frame.width)
         }
         panel.setFrameOrigin(origin)
         panel.orderFront(nil)
     }
 
+    /// Toggle the BSM code column while keeping the panel where it is.
+    public func setShowsCode(_ showsCode: Bool) {
+        self.showsCode = showsCode
+        render()
+    }
+
     public func hide() {
         panel.orderOut(nil)
+    }
+
+    private func render() {
+        hostingView.rootView = CandidateListView(
+            candidates: candidates,
+            showsCode: showsCode,
+            selectedIndex: selectedIndex
+        )
+        panel.setContentSize(hostingView.fittingSize)
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -36,6 +36,8 @@ targets:
         product: BSMCore
       - package: BSMCore
         product: BSMCandidateUI
+      - package: BSMCore
+        product: BSMDictionarySQLite
     settings:
       base:
         PRODUCT_NAME: BSMInputMethod


### PR DESCRIPTION
Implements #8 — wires the real input method together end-to-end, replacing the skeleton echo (ADR 0008, 0009, 0010). **Stacked on #14.**

## What's here
`InputController` (`IMKInputController`) → `ComposingBuffer` → `CandidateDictionary` → Candidate List window:
- **Full keypad map** ported from the legacy controller: stroke digits and `*` extend the BSM Code; `.` enters Selection Mode; `1`–`9` select a candidate and commit; `/` and `=` page with wrap (beep on wrap); `+` toggles the muted code column; `-` deletes backward; Enter/Space commit the first candidate; Clear resets.
- Marked text driven from the Stroke Marker with raw-text styling; Candidate List positioned near the caret via the line-height rectangle.
- Commit / cancel / server-deactivation handled, including the Terminal premature-commit workaround.
- `SharedServices` holds the process-wide read-only dictionary over bundled `bsm.db` and the single Candidate List window; app now links `BSMDictionarySQLite`.

## Verification
- `swift test` — 37 tests green (no regressions).
- `xcodebuild -scheme BSMInputMethod build` — **BUILD SUCCEEDED**.
- Confirmed the ObjC class `_TtC14BSMInputMethod15InputController` (= `BSMInputMethod.InputController`, superclass `IMKInputController`) is in the binary, so the Info.plist controller class resolves at load.

## HITL
Live typing parity — install to `~/Library/Input Methods`, enable, and exercise the full numpad flow against the legacy behavior — needs a GUI session. Please verify from a logged-in session.

Refs ADR 0008, 0009, 0010.
