### PR TITLE
Packaging and in-place upgrade verification (#9)

### DIFF
--- a/Legacy/README.md
+++ b/Legacy/README.md
@@ -1,0 +1,112 @@
+# 筆順碼輸入法 for Mac OS X
+
+這是筆順碼輸入法的 Mac OS X 版本。
+
+## 安裝
+
+### 使用 Homebrew
+
+1. ``brew install siuying/tap/bsm``
+2. 在 "系統偏好設定" > "語言與文字" > "輸入來源" 下選取 "BSM 筆順碼"
+3. 如果你使用的是 Apple Silicon Mac，請先安裝 Rosetta (```/usr/sbin/softwareupdate --install-rosetta --agree-to-license```)，然後手動執行 ```/Library/Input Methods/BSMInputMethod.app``` 一次。
+4. 如果你使用的是 Mojave 或以上，需要到 "系統偏好設定" > "安全性和私隱" 容許執行 BSM Input Method。
+5. 按 ctrl-space 直到轉到 "BSM 筆順碼"
+
+### 手動安裝
+
+1. 下載[程式](https://www.dropbox.com/s/dnbl52tfasq2hfm/BSMInputMethod_0.3.2.zip)
+2. 解壓後，把程式檔 (BSMInputMethod.app) 複制到 ```/Users/<User-Name>/Library/Input Methods``` 資夾下
+3. 在 "系統偏好設定" > "語言與地區" > "鍵盤編好設定" > "輸入方式" > "+" > 在「繁體中文」下選取「BSM 筆順碼」
+4. 如果你使用的是 Mojave 或以上，需要到 "系統偏好設定" > "安全性和私隱" 容許執行 BSM Input Method
+5. 如果你使用的是 Apple Silicon Mac，請先安裝 Rosetta (```/usr/sbin/softwareupdate --install-rosetta --agree-to-license```)，然後手動執行 ```/Library/Input Methods/BSMInputMethod.app``` 一次。
+6. 按 command-space 直到轉到 "BSM 筆順碼"
+
+## 為何要做這個輸入法？
+
+因為這個輸入法很簡單很易學，自從 Windows 95 時代用了半小時便學懂，之後我再也不想再學其他的輸入法了。
+
+可惜這個輸入法自2000年便沒有更新，而且香港的代理也倒閉了。本來我一直使用其 Java Applet 版本，但因為最近 Java 的安全性問題，要在 browser 開它也不大方便，終於要自己動手寫一個代用品了。
+
+## 輸入法使用法
+
+筆順碼以數字鍵盤輸入，每個數字代表一種筆畫。跟一般筆劃輸入法不同，筆順碼將每個字的頭三筆和由最尾倒數的三筆代表一個字。因此做到最少一碼，最多六碼代表所有中文字。
+
+十個數字鍵分別代表以下筆畫：
+
+1. 橫 - 如「明」的第二筆、「天」的頭兩筆
+2. 直 - 如「工」的第二筆、「作」的第二筆
+3. 撇 - 如「我」的第一筆、「的」的第一筆
+4. 捺和點 - 如「旅」和「遊」的第一筆
+5. 順時針勾 - 如「刀」和「書」的第一筆
+6. 逆時針勾 - 如「以」的第一筆、「組」的頭兩筆
+7. 交叉 - 如「子」的第一筆、「時」的尾二筆、「切」的第一筆、「文」的最尾一筆
+8. 人、八或兩點 - 如「次」的第一筆、「暴」的尾兩筆
+9. 十字型 - 如「其」的第一筆、「物」的第二筆、「田」的第二筆
+10. 口字型 - 如「各」的最尾一筆和「國」的第一筆
+
+數字鍵的以下鍵有特殊功能：
+
+- . 選字鍵，當選字表有想要的字時，可以按 . 再按字碼數字，如 .3 代表第三字
+- Enter 選擇選字表第一個字，和 .1 一樣效果
+- * 萬用鍵，代表一個或更代的鍵
+- - 減去一個輸入
+- Clear 清除所有輸入
+- = 選字表上一頁
+- / 選字表下一頁
+- + 顯示選字表的字的字碼
+
+如「順」字可以輸入 3228 enter 或 322801.3 「順」
+
+標點符號的字碼為 60-62、933-939。
+
+參考：
+
+- [筆順碼筆劃](http://web.archive.org/web/20090106155430/http://www.freefire.com.hk/other/input02.htm)
+- [輸入示範 - 常見的首三碼](http://web.archive.org/web/20080615024154/http://www.freefire.com.hk/other/demo01.htm)
+- [輸入示範 - 常見的尾三碼](http://web.archive.org/web/20080615180037/http://www.freefire.com.hk/other/demo02.htm)
+- [輸入示範 - 示範1](http://web.archive.org/web/20080615180042/http://www.freefire.com.hk/other/demo03.htm)
+- [輸入示範 - 示範2](http://web.archive.org/web/20080615180042/http://www.freefire.com.hk/other/demo04.htm)
+
+## 版本
+
+### 0.3.2
+
+- 按空白鍵等同 Enter (選字)
+
+### 0.3.1
+
+- 修正使用 "-" 鍵時遇上的問題
+
+### 0.3.0
+
+- 按 "*" 可以做萬用字元，代表任何字碼
+- 按 "+" 可以在選字表顯示字碼
+- (實驗性) 以字頻去排序：使用萬用字元時會返回大量的結果，使用字頻去排序使用者更易找到想找的字。不影響正常輸入。
+- 其他小改進
+
+### 0.2.0
+
+- 選字時，按 "/" 去下一頁、按 "=" 去上一頁
+- 輸入時按 "Clear" 可清除所有已輸入的字碼
+- 其他小改進
+
+### 0.1.1
+
+- 修正一些快速輸入時的問題
+
+### 0.1.0
+
+- 第一個版本。以 applet 版輸入法為基本設計。
+- 基本功能完成，需要多點時間測試和除錯。
+
+## 授權
+
+本程式碼以 MIT License 授權。
+
+輸入法和其碼表由其原本持有人版權所有。
+
+## Attribution
+
+- data/bsm_applet.dat - 由筆順碼 applet 版抽出的檔案
+- data/BIAU1.TXT - 台灣教育部「[字頻總表](http://www.edu.tw/files/site_content/m0001/pin/yu7.htm?open)」
+

--- a/README.md
+++ b/README.md
@@ -1,112 +1,87 @@
-# 筆順碼輸入法 for Mac OS X
+# BSM Input Method (筆順碼輸入法) for macOS
 
-這是筆順碼輸入法的 Mac OS X 版本。
+A modern Swift rewrite of the BSM (筆順碼 / stroke-order code) macOS input method.
+The input method is driven entirely by the numeric keypad: each digit is a
+stroke class, and one to six strokes identify a character.
 
-## 安裝
+This repository is the modern Swift project. The original Objective-C /
+CocoaPods / Ruby implementation is preserved under [`Legacy/`](Legacy/) for
+reference, and the original usage guide and stroke table live in
+[`Legacy/README.md`](Legacy/README.md).
 
-### 使用 Homebrew
+## Requirements
 
-1. ``brew install siuying/tap/bsm``
-2. 在 "系統偏好設定" > "語言與文字" > "輸入來源" 下選取 "BSM 筆順碼"
-3. 如果你使用的是 Apple Silicon Mac，請先安裝 Rosetta (```/usr/sbin/softwareupdate --install-rosetta --agree-to-license```)，然後手動執行 ```/Library/Input Methods/BSMInputMethod.app``` 一次。
-4. 如果你使用的是 Mojave 或以上，需要到 "系統偏好設定" > "安全性和私隱" 容許執行 BSM Input Method。
-5. 按 ctrl-space 直到轉到 "BSM 筆順碼"
+- macOS 14 or later
+- Xcode 16 or later (Swift 6)
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen) (`brew install xcodegen`)
 
-### 手動安裝
+## Project layout
 
-1. 下載[程式](https://www.dropbox.com/s/dnbl52tfasq2hfm/BSMInputMethod_0.3.2.zip)
-2. 解壓後，把程式檔 (BSMInputMethod.app) 複制到 ```/Users/<User-Name>/Library/Input Methods``` 資夾下
-3. 在 "系統偏好設定" > "語言與地區" > "鍵盤編好設定" > "輸入方式" > "+" > 在「繁體中文」下選取「BSM 筆順碼」
-4. 如果你使用的是 Mojave 或以上，需要到 "系統偏好設定" > "安全性和私隱" 容許執行 BSM Input Method
-5. 如果你使用的是 Apple Silicon Mac，請先安裝 Rosetta (```/usr/sbin/softwareupdate --install-rosetta --agree-to-license```)，然後手動執行 ```/Library/Input Methods/BSMInputMethod.app``` 一次。
-6. 按 command-space 直到轉到 "BSM 筆順碼"
+| Path | What it is |
+| --- | --- |
+| `project.yml` | XcodeGen spec for the app, Example app, and UI tests |
+| `Package.swift` | Swift package: `BSMCore`, `BSMCandidateUI`, `BSMDictionarySQLite`, and the `bsm-db-build` tool |
+| `App/` | The input method app: `IMKInputController` glue and `Info.plist` |
+| `Sources/BSMCore/` | Pure domain: Composing Buffer, BSM Code / Stroke Marker, candidate dictionary protocol |
+| `Sources/BSMCandidateUI/` | SwiftUI Candidate List and its `NSPanel` host |
+| `Sources/BSMDictionarySQLite/` | SQLite.swift-backed dictionary (behind the `CandidateDictionary` boundary) |
+| `Sources/BSMDatabaseBuilder/` | `bsm-db-build` CLI that regenerates `bsm.db` |
+| `Example/` | Standalone app for visually reviewing / UI-testing the Candidate List |
+| `Data/` | Bundled `bsm.db` and its UTF-8 dictionary sources |
+| `docs/adr/` | Architecture decision records |
+| `CONTEXT.md` | Domain glossary |
 
-## 為何要做這個輸入法？
+The deployment shape and the major decisions are recorded in
+[`docs/adr/`](docs/adr/); the domain language is in [`CONTEXT.md`](CONTEXT.md).
 
-因為這個輸入法很簡單很易學，自從 Windows 95 時代用了半小時便學懂，之後我再也不想再學其他的輸入法了。
+## Build and test
 
-可惜這個輸入法自2000年便沒有更新，而且香港的代理也倒閉了。本來我一直使用其 Java Applet 版本，但因為最近 Java 的安全性問題，要在 browser 開它也不大方便，終於要自己動手寫一個代用品了。
+```sh
+# Pure domain + dictionary + builder tests (fast, no Xcode UI):
+swift test
 
-## 輸入法使用法
+# Generate and build the app:
+xcodegen generate
+xcodebuild -project BSMInputMethod.xcodeproj -scheme BSMInputMethod build
 
-筆順碼以數字鍵盤輸入，每個數字代表一種筆畫。跟一般筆劃輸入法不同，筆順碼將每個字的頭三筆和由最尾倒數的三筆代表一個字。因此做到最少一碼，最多六碼代表所有中文字。
+# Candidate List Example app and its XCUITests:
+xcodebuild -project BSMInputMethod.xcodeproj -scheme BSMExample test
+```
 
-十個數字鍵分別代表以下筆畫：
+## Install
 
-1. 橫 - 如「明」的第二筆、「天」的頭兩筆
-2. 直 - 如「工」的第二筆、「作」的第二筆
-3. 撇 - 如「我」的第一筆、「的」的第一筆
-4. 捺和點 - 如「旅」和「遊」的第一筆
-5. 順時針勾 - 如「刀」和「書」的第一筆
-6. 逆時針勾 - 如「以」的第一筆、「組」的頭兩筆
-7. 交叉 - 如「子」的第一筆、「時」的尾二筆、「切」的第一筆、「文」的最尾一筆
-8. 人、八或兩點 - 如「次」的第一筆、「暴」的尾兩筆
-9. 十字型 - 如「其」的第一筆、「物」的第二筆、「田」的第二筆
-10. 口字型 - 如「各」的最尾一筆和「國」的第一筆
+```sh
+./Scripts/install.sh
+```
 
-數字鍵的以下鍵有特殊功能：
+This builds Release and copies `BSMInputMethod.app` into
+`~/Library/Input Methods`. The bundle preserves the legacy input source identity
+(bundle id `hk.ignition.inputmethod.BSMInputMethod`), so installing over an
+existing version upgrades it in place — it stays enabled with no re-enable or
+re-login. For a first install, enable it under **System Settings → Keyboard →
+Text Input → Input Sources → + → Traditional Chinese → BSM**.
 
-- . 選字鍵，當選字表有想要的字時，可以按 . 再按字碼數字，如 .3 代表第三字
-- Enter 選擇選字表第一個字，和 .1 一樣效果
-- * 萬用鍵，代表一個或更代的鍵
-- - 減去一個輸入
-- Clear 清除所有輸入
-- = 選字表上一頁
-- / 選字表下一頁
-- + 顯示選字表的字的字碼
+## Rebuilding the dictionary
 
-如「順」字可以輸入 3228 enter 或 322801.3 「順」
+`Data/bsm.db` is committed and bundled directly. To regenerate it from the
+UTF-8 dictionary sources in `Data/`:
 
-標點符號的字碼為 60-62、933-939。
+```sh
+swift run bsm-db-build Data Data/bsm.db
+```
 
-參考：
+The sources were converted once from the original BIG5 / BIG5-HKSCS data via
+`Tools/convert-legacy-sources.py`; the originals remain under `Legacy/data/`.
 
-- [筆順碼筆劃](http://web.archive.org/web/20090106155430/http://www.freefire.com.hk/other/input02.htm)
-- [輸入示範 - 常見的首三碼](http://web.archive.org/web/20080615024154/http://www.freefire.com.hk/other/demo01.htm)
-- [輸入示範 - 常見的尾三碼](http://web.archive.org/web/20080615180037/http://www.freefire.com.hk/other/demo02.htm)
-- [輸入示範 - 示範1](http://web.archive.org/web/20080615180042/http://www.freefire.com.hk/other/demo03.htm)
-- [輸入示範 - 示範2](http://web.archive.org/web/20080615180042/http://www.freefire.com.hk/other/demo04.htm)
+## Usage
 
-## 版本
+BSM codes are typed on the numeric keypad. See
+[`Legacy/README.md`](Legacy/README.md) for the full stroke table and examples;
+in brief: `1`–`9`/`0` are stroke classes, `.` then a digit selects a candidate,
+`Enter`/`Space` commit the first candidate, `*` is a wildcard, `-` deletes,
+`/` and `=` page, `+` toggles the code column, and `Clear` resets.
 
-### 0.3.2
+## License
 
-- 按空白鍵等同 Enter (選字)
-
-### 0.3.1
-
-- 修正使用 "-" 鍵時遇上的問題
-
-### 0.3.0
-
-- 按 "*" 可以做萬用字元，代表任何字碼
-- 按 "+" 可以在選字表顯示字碼
-- (實驗性) 以字頻去排序：使用萬用字元時會返回大量的結果，使用字頻去排序使用者更易找到想找的字。不影響正常輸入。
-- 其他小改進
-
-### 0.2.0
-
-- 選字時，按 "/" 去下一頁、按 "=" 去上一頁
-- 輸入時按 "Clear" 可清除所有已輸入的字碼
-- 其他小改進
-
-### 0.1.1
-
-- 修正一些快速輸入時的問題
-
-### 0.1.0
-
-- 第一個版本。以 applet 版輸入法為基本設計。
-- 基本功能完成，需要多點時間測試和除錯。
-
-## 授權
-
-本程式碼以 MIT License 授權。
-
-輸入法和其碼表由其原本持有人版權所有。
-
-## Attribution
-
-- data/bsm_applet.dat - 由筆順碼 applet 版抽出的檔案
-- data/BIAU1.TXT - 台灣教育部「[字頻總表](http://www.edu.tw/files/site_content/m0001/pin/yu7.htm?open)」
-
+MIT (see `Legacy/README.md`). The input method and its code table are
+copyright their original holders.

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the modern BSM Input Method in Release and install it to the user's
+# Input Methods directory. Because the bundle keeps the legacy input source
+# identity (ADR 0009), this upgrades an existing install in place — the input
+# source stays enabled with no re-enable or re-login.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DEST="$HOME/Library/Input Methods"
+APP="BSMInputMethod.app"
+BUILD_DIR="build"
+
+echo "==> Generating Xcode project"
+xcodegen generate
+
+echo "==> Building Release"
+xcodebuild -project BSMInputMethod.xcodeproj \
+    -scheme BSMInputMethod \
+    -configuration Release \
+    -derivedDataPath "$BUILD_DIR" \
+    build
+
+PRODUCT="$BUILD_DIR/Build/Products/Release/$APP"
+if [[ ! -d "$PRODUCT" ]]; then
+    echo "error: $PRODUCT was not produced" >&2
+    exit 1
+fi
+
+echo "==> Installing to $DEST"
+mkdir -p "$DEST"
+# Terminate a running instance so the bundle can be replaced cleanly.
+killall BSMInputMethod 2>/dev/null || true
+rm -rf "$DEST/$APP"
+cp -R "$PRODUCT" "$DEST/$APP"
+
+echo "==> Installed $DEST/$APP"
+echo "If this is a first install, enable it in System Settings >"
+echo "Keyboard > Text Input > Input Sources > + > Traditional Chinese > BSM."


### PR DESCRIPTION
Implements #9 — packaging, the modern README, and the in-place upgrade guarantee (ADR 0009). **Stacked on #15.**

## What's here
- **`Scripts/install.sh`** — builds Release and installs `BSMInputMethod.app` into `~/Library/Input Methods` (terminating any running instance first).
- **Legacy README moved** to `Legacy/README.md` (keeps the original usage guide, stroke table, and attribution).
- **New root `README.md`** — documents the modern Swift/XcodeGen project: layout, `swift test` / `xcodebuild` commands, install, and the `bsm-db-build` dictionary rebuild.

## Verification
- `xcodebuild -configuration Release build` — **BUILD SUCCEEDED**.
- Release bundle keeps `CFBundleIdentifier` / `TISInputSourceID` / `InputMethodConnectionName` identical to the legacy app, so an existing install upgrades in place and stays enabled.

## HITL
Verifying a live in-place upgrade — installing over a machine that already had the legacy BSM enabled and confirming it stays enabled without re-login — needs a real session. Please verify.

Refs ADR 0009.
